### PR TITLE
Fix vehicle state for spectated player

### DIFF
--- a/Internal/Vehicle/VehicleNext.as
+++ b/Internal/Vehicle/VehicleNext.as
@@ -22,7 +22,7 @@ namespace VehicleState
 			if (type is null) {
 				error("Unable to find reflection info for CSmPlayer!");
 			}
-			g_offsetSpawnableObjectModelIndex = type.GetMember("SpawnableObjectModelIndex").Offset - 0x14;
+			g_offsetSpawnableObjectModelIndex = type.GetMember("SpawnableObjectModelIndex").Offset - 0x20;
 		}
 
 		// Get the ID and make sure it actually matches the 0x02000000 mask


### PR DESCRIPTION
Offset appears to be wrong and always returns the same player's vehicle state, regardless of who is being spectated.
With the new offset, spectating appears to work as intended,