### PR TITLE
Implement full vehicle vis support for MP4.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.sig
+*.sh
+.vscode/**/*

--- a/Debugger/Main.as
+++ b/Debugger/Main.as
@@ -10,7 +10,7 @@ namespace VehicleDebugger
 				UI::EndTabItem();
 			}
 
-#if TMNEXT
+#if TMNEXT || MP4
 			if (UI::BeginTabItem(Icons::Kenney::Users + " Player states")) {
 				TabPlayerStates();
 				UI::EndTabItem();
@@ -41,7 +41,7 @@ namespace VehicleDebugger
 		RenderVehicleState(vehicle);
 	}
 
-#if TMNEXT
+#if TMNEXT || MP4
 	void TabPlayerStates()
 	{
 		auto app = GetApp();
@@ -59,7 +59,11 @@ namespace VehicleDebugger
 		}
 
 		for (uint i = 0; i < pg.Players.Length; i++) {
+#if TMNEXT
 			auto player = cast<CSmPlayer>(pg.Players[i]);
+#elif MP4
+			auto player = cast<CTrackManiaPlayer>(pg.Players[i]);
+#endif
 			if (player is null) {
 				continue;
 			}
@@ -72,6 +76,7 @@ namespace VehicleDebugger
 			UI::PushID(player.User.Name);
 
 			if (UI::CollapsingHeader(player.User.Name)) {
+				UI::LabelText("Entity ID", Text::Format("%08x", VehicleState::GetEntityId(vehicle)));
 				RenderVehicleState(vehicle);
 			}
 
@@ -134,15 +139,24 @@ namespace VehicleDebugger
 		UI::LabelText("GroundDist", "" + state.GroundDist);
 		UI::LabelText("FrontSpeed", "" + state.FrontSpeed);
 
-#if TMNEXT
+#if TMNEXT || MP4
 		if (Setting_DisplayExtendedInformation) {
+			UI::LabelText("Position", state.Position.ToString());
+			UI::LabelText("Dir", state.Dir.ToString());
+			UI::LabelText("FLDamperLen", "" + state.FLDamperLen);
 			UI::LabelText("FLSteerAngle", "" + state.FLSteerAngle);
 			UI::LabelText("FLWheelRot", "" + state.FLWheelRot);
 			UI::LabelText("FLSlipCoef", "" + state.FLSlipCoef);
+#if TMNEXT
 			UI::LabelText("FL Dirt", "" + VehicleState::GetWheelDirt(state, 0));
 			UI::LabelText("FLIcing01", "" + state.FLIcing01);
 			UI::LabelText("FLTireWear01", "" + state.FLTireWear01);
 			UI::LabelText("FLBreakNormedCoef", "" + state.FLBreakNormedCoef);
+#elif MP4
+			UI::LabelText("FLGroundContactMaterial", "" + tostring(state.FLGroundContactMaterial));
+			UI::LabelText("FLIsWet", "" + state.FLIsWet);
+			UI::LabelText("FLGroundContact", "" + state.FLGroundContact);
+#endif
 		}
 #endif
 	}

--- a/Debugger/Main.as
+++ b/Debugger/Main.as
@@ -109,7 +109,7 @@ namespace VehicleDebugger
 #endif
 
 #if MP4
-	void RenderVehicleState(CSceneVehicleVisInner@ vehicle)
+	void RenderVehicleState(CSceneVehicleVisState@ vehicle)
 #else
 	void RenderVehicleState(CSceneVehicleVis@ vehicle)
 #endif

--- a/Export.as
+++ b/Export.as
@@ -1,11 +1,13 @@
 namespace VehicleState
 {
-	// Gets the currently viewed player. This can be the local player or the player being spectated.
 #if TMNEXT
+	// Gets the currently viewed player. This can be the local player or the player being spectated.
 	import CSmPlayer@ GetViewingPlayer() from "VehicleState";
 #elif TURBO
+	// Gets the currently viewed player. This can be the local player or the player being spectated.
 	import CGameMobil@ GetViewingPlayer() from "VehicleState";
 #elif MP4
+	// Gets the currently viewed player. This will always be the local player.
 	import CGamePlayer@ GetViewingPlayer() from "VehicleState";
 #endif
 
@@ -35,5 +37,16 @@ namespace VehicleState
 
 	// Get all vehicle vis states. Mostly used for debugging.
 	import array<CSceneVehicleVis@> GetAllVis(ISceneVis@ sceneVis) from "VehicleState";
+#endif
+
+#if MP4
+	// Get vehicle vis from a given player.
+	import CSceneVehicleVisState@ GetVis(CGameScene@ sceneVis, CGamePlayer@ player) from "VehicleState";
+
+	// Get the only existing vehicle vis state, if there is only one. Otherwise, this returns null.
+	import CSceneVehicleVisState@ GetSingularVis(CGameScene@ sceneVis) from "VehicleState";
+
+	// Get all vehicle vis states. Mostly used for debugging.
+	import array<CSceneVehicleVisState@> GetAllVis(CGameScene@ sceneVis) from "VehicleState";
 #endif
 }

--- a/Export.as
+++ b/Export.as
@@ -37,9 +37,7 @@ namespace VehicleState
 
 	// Get all vehicle vis states. Mostly used for debugging.
 	import array<CSceneVehicleVis@> GetAllVis(ISceneVis@ sceneVis) from "VehicleState";
-#endif
-
-#if MP4
+#elif MP4
 	// Get vehicle vis from a given player.
 	import CSceneVehicleVisState@ GetVis(CGameScene@ sceneVis, CGamePlayer@ player) from "VehicleState";
 

--- a/Internal/Impl.as
+++ b/Internal/Impl.as
@@ -39,7 +39,7 @@ namespace VehicleState
 
 #if MP4
 		CGameScene@ sceneVis = app.GameScene;
-		CSceneVehicleVisInner@ vis = null;
+		CSceneVehicleVisState@ vis = null;
 #else
 		auto sceneVis = app.GameScene;
 		if (sceneVis is null) {
@@ -49,8 +49,10 @@ namespace VehicleState
 #endif
 
 #if MP4
-		@vis = GetVisWithId(GetViewingVisId());
-		return vis is null ? null : vis.AsyncState;
+		auto visInner = GetVisWithId(GetViewingVisId());
+		if (visInner !is null) {
+			@vis = visInner.AsyncState;
+		}
 #else
 		auto player = GetViewingPlayer();
 		if (player !is null) {
@@ -58,8 +60,9 @@ namespace VehicleState
 		} else {
 			@vis = VehicleState::GetSingularVis(sceneVis);
 		}
-		return vis;
 #endif
+
+		return vis;
 	}
 
 	CSceneVehicleVisState@ ViewingPlayerState()

--- a/Internal/Impl.as
+++ b/Internal/Impl.as
@@ -30,7 +30,7 @@ namespace VehicleState
 #endif
 
 #if MP4
-	CSceneVehicleVisInner@ ViewingPlayerVis()
+	CSceneVehicleVisState@ ViewingPlayerVis()
 #else
 	CSceneVehicleVis@ ViewingPlayerVis()
 #endif
@@ -50,6 +50,7 @@ namespace VehicleState
 
 #if MP4
 		@vis = GetVisWithId(GetViewingVisId());
+		return vis is null ? null : vis.AsyncState;
 #else
 		auto player = GetViewingPlayer();
 		if (player !is null) {
@@ -57,9 +58,8 @@ namespace VehicleState
 		} else {
 			@vis = VehicleState::GetSingularVis(sceneVis);
 		}
-#endif
-
 		return vis;
+#endif
 	}
 
 	CSceneVehicleVisState@ ViewingPlayerState()

--- a/Internal/Impl.as
+++ b/Internal/Impl.as
@@ -38,7 +38,7 @@ namespace VehicleState
 		auto app = GetApp();
 
 #if MP4
-		CGameScene@ sceneVis = null;
+		CGameScene@ sceneVis = app.GameScene;
 		CSceneVehicleVisInner@ vis = null;
 #else
 		auto sceneVis = app.GameScene;
@@ -48,12 +48,16 @@ namespace VehicleState
 		CSceneVehicleVis@ vis = null;
 #endif
 
+#if MP4
+		@vis = GetVisWithId(GetViewingVisId());
+#else
 		auto player = GetViewingPlayer();
 		if (player !is null) {
 			@vis = VehicleState::GetVis(sceneVis, player);
 		} else {
 			@vis = VehicleState::GetSingularVis(sceneVis);
 		}
+#endif
 
 		return vis;
 	}

--- a/Internal/SceneVis.as
+++ b/Internal/SceneVis.as
@@ -65,4 +65,18 @@ namespace SceneVis
 		return ret;
 	}
 }
+
+#elif MP4
+
+namespace SceneVis
+{
+	CSceneMgrVehicleVisImpl@ GetManager(CGameScene@ scene)
+	{
+		if (scene is null || scene.MgrVehicleVis is null) {
+			return null;
+		}
+		return scene.MgrVehicleVis.Impl;
+	}
+}
+
 #endif

--- a/Internal/SceneVis.as
+++ b/Internal/SceneVis.as
@@ -70,7 +70,7 @@ namespace SceneVis
 
 namespace SceneVis
 {
-	CSceneMgrVehicleVisImpl@ GetManager(CGameScene@ scene)
+	CSceneMgrVehicleVisImpl@ GetVehicleVisManager(CGameScene@ scene)
 	{
 		if (scene is null || scene.MgrVehicleVis is null) {
 			return null;

--- a/Internal/Vehicle/VehicleMP4.as
+++ b/Internal/Vehicle/VehicleMP4.as
@@ -129,7 +129,6 @@ namespace VehicleState
 
 		if (mgr !is null && CheckValidVehicles(mgr)) {
 			auto vehiclesCount = GetVisCount(mgr);
-			// auto vehicles = Dev::GetOffsetUint32(mgr, VehiclesOffset);
 			for (uint i = 0; i < vehiclesCount; i++) {
 				ret.InsertLast(CSceneVehicleVisInner(VehicleState::_GetVisNodAt(mgr, i)));
 			}

--- a/Internal/Vehicle/VehicleMP4.as
+++ b/Internal/Vehicle/VehicleMP4.as
@@ -9,13 +9,34 @@ class CSceneVehicleVisInner
 	CSceneVehicleVisInner(CGamePlayer@ player)
 	{
 		@m_player = cast<CTrackManiaPlayer>(player);
+		if (m_player !is null) {
+			@AsyncState = CSceneVehicleVisState(Dev::GetOffsetNod(m_player, 0x2b8));
+		}
+	}
 
-		@AsyncState = CSceneVehicleVisState(m_player);
+	CSceneVehicleVisInner(CSceneMgrVehicleVisImpl@ mgr, uint index)
+	{
+		@AsyncState = CSceneVehicleVisState(VehicleState::_GetVisNodAt(mgr, index));
+	}
+
+	CSceneVehicleVisInner(CMwNod@ nod)
+	{
+		@AsyncState = CSceneVehicleVisState(nod);
+	}
+
+	uint get_EntityId()
+	{
+		if (m_player !is null) {
+			return Dev::GetOffsetUint32(m_player, 0x2c4);
+		}
+		return Dev::GetOffsetUint32(AsyncState.m_vis, 0x0);
 	}
 }
 
 namespace VehicleState
 {
+	uint VehiclesOffset = 0x38;
+
 	// Get vehicle vis from a given player.
 	CSceneVehicleVisInner@ GetVis(CGameScene@ sceneVis, CGamePlayer@ player)
 	{
@@ -28,7 +49,93 @@ namespace VehicleState
 	// Not used for anything in MP4 afaik, but keeping the interface identical.
 	CSceneVehicleVisInner@ GetSingularVis(CGameScene@ sceneVis)
 	{
+		auto mgr = SceneVis::GetManager(sceneVis);
+
+		if (CheckValidVehicles(mgr) && GetVisCount(mgr) == 1) {
+			return CSceneVehicleVisInner(mgr, 0);
+		}
+
 		return null;
+	}
+
+	uint GetViewingVisId()
+	{
+		auto app = GetApp();
+		auto cam = app.GameCamera;
+		// the game uses this during intro/podium scenes.
+		if (cam is null) return 0x0FF00000;
+		return Dev::GetOffsetUint32(cam, 0xd4);
+	}
+
+	CSceneVehicleVisInner@ GetVisWithId(uint VisId)
+	{
+		auto mgr = SceneVis::GetManager(GetApp().GameScene);
+		if (mgr !is null && CheckValidVehicles(mgr)) {
+			auto vehiclesCount = GetVisCount(mgr);
+			auto vehicles = Dev::GetOffsetNod(mgr, VehiclesOffset);
+			for (uint i = 0; i < vehiclesCount; i++) {
+				auto vis = Dev::GetOffsetNod(vehicles, i * 0x8);
+				if (Dev::GetOffsetUint32(vis, 0x0) == VisId) {
+					return CSceneVehicleVisInner(vis);
+				}
+			}
+		}
+		return null;
+	}
+
+	uint GetVisCount(CSceneMgrVehicleVisImpl@ mgr)
+	{
+		auto count = Dev::GetOffsetUint32(mgr, VehiclesOffset + 0x8);
+		// Assume we cannot have more than 1000 vehicles
+		if (count > 1000) return 0;
+		return count;
+	}
+
+	// Get the raw vehicle vis at a particular index
+	CMwNod@ _GetVisNodAt(CSceneMgrVehicleVisImpl@ mgr, uint index)
+	{
+		if (index >= GetVisCount(mgr)) {
+			return null;
+		}
+		auto vehicles = Dev::GetOffsetNod(mgr, VehiclesOffset);
+		return Dev::GetOffsetNod(vehicles, index * 0x8);
+	}
+
+	bool CheckValidVehicles(CSceneMgrVehicleVisImpl@ mgr)
+	{
+		if (mgr is null) return false;
+
+		auto ptr = Dev::GetOffsetUint64(mgr, VehiclesOffset);
+		auto count = Dev::GetOffsetUint32(mgr, VehiclesOffset + 0x8);
+
+		// Ensure this is a valid pointer
+		if ((ptr & 0xF) != 0) {
+			return false;
+		}
+
+		// Assume we can't have more than 1000 vehicles
+		if (count > 1000) {
+			return false;
+		}
+
+		return true;
+	}
+
+	// Get all vehicle vis states. Mostly used for debugging.
+	array<CSceneVehicleVisInner@> GetAllVis(CGameScene@ sceneVis)
+	{
+		array<CSceneVehicleVisInner@> ret;
+		auto mgr = SceneVis::GetManager(sceneVis);
+
+		if (mgr !is null && CheckValidVehicles(mgr)) {
+			auto vehiclesCount = GetVisCount(mgr);
+			// auto vehicles = Dev::GetOffsetUint32(mgr, VehiclesOffset);
+			for (uint i = 0; i < vehiclesCount; i++) {
+				ret.InsertLast(CSceneVehicleVisInner(VehicleState::_GetVisNodAt(mgr, i)));
+			}
+		}
+
+		return ret;
 	}
 
 	// Get RPM for vehicle vis. This is contained within the state, but not exposed by default, which
@@ -47,8 +154,7 @@ namespace VehicleState
 	// Get entity ID of the given vehicle vis.
 	uint GetEntityId(CSceneVehicleVisInner@ vis)
 	{
-		// Not present
-		return 0;
+		return vis.EntityId;
 	}
 }
 #endif

--- a/Internal/Vehicle/VehicleMP4.as
+++ b/Internal/Vehicle/VehicleMP4.as
@@ -10,13 +10,14 @@ class CSceneVehicleVisInner
 	{
 		@m_player = cast<CTrackManiaPlayer>(player);
 		if (m_player !is null) {
+			// The player class has a pointer to the player's vehicle vis at 0x2B8. This is the same pointer as found via VehicleVisMgr.
 			@AsyncState = CSceneVehicleVisState(Dev::GetOffsetNod(m_player, 0x2b8));
 		}
 	}
 
 	CSceneVehicleVisInner(CSceneMgrVehicleVisImpl@ mgr, uint index)
 	{
-		@AsyncState = CSceneVehicleVisState(VehicleState::_GetVisNodAt(mgr, index));
+		@AsyncState = CSceneVehicleVisState(VehicleState::GetVisNodAt(mgr, index));
 	}
 
 	CSceneVehicleVisInner(CMwNod@ nod)
@@ -24,7 +25,7 @@ class CSceneVehicleVisInner
 		@AsyncState = CSceneVehicleVisState(nod);
 	}
 
-	uint get_EntityId()
+	uint GetEntityId()
 	{
 		if (m_player !is null) {
 			return Dev::GetOffsetUint32(m_player, 0x2c4);
@@ -46,10 +47,10 @@ namespace VehicleState
 		return CSceneVehicleVisInner(player);
 	}
 
-	// Not used for anything in MP4 afaik, but keeping the interface identical.
+	// Get the only existing vehicle vis state, if there is only one. Otherwise, this returns null.
 	CSceneVehicleVisInner@ GetSingularVis(CGameScene@ sceneVis)
 	{
-		auto mgr = SceneVis::GetManager(sceneVis);
+		auto mgr = SceneVis::GetVehicleVisManager(sceneVis);
 
 		if (CheckValidVehicles(mgr) && GetVisCount(mgr) == 1) {
 			return CSceneVehicleVisInner(mgr, 0);
@@ -63,21 +64,24 @@ namespace VehicleState
 		auto app = GetApp();
 		auto cam = app.GameCamera;
 		// the game uses this during intro/podium scenes.
-		if (cam is null) return 0x0FF00000;
+		if (cam is null) {
+			return 0x0FF00000;
+		}
 		return Dev::GetOffsetUint32(cam, 0xd4);
 	}
 
 	CSceneVehicleVisInner@ GetVisWithId(uint VisId)
 	{
-		auto mgr = SceneVis::GetManager(GetApp().GameScene);
-		if (mgr !is null && CheckValidVehicles(mgr)) {
-			auto vehiclesCount = GetVisCount(mgr);
-			auto vehicles = Dev::GetOffsetNod(mgr, VehiclesOffset);
-			for (uint i = 0; i < vehiclesCount; i++) {
-				auto vis = Dev::GetOffsetNod(vehicles, i * 0x8);
-				if (Dev::GetOffsetUint32(vis, 0x0) == VisId) {
-					return CSceneVehicleVisInner(vis);
-				}
+		auto mgr = SceneVis::GetVehicleVisManager(GetApp().GameScene);
+		if (mgr is null || !CheckValidVehicles(mgr)) {
+			return null;
+		}
+		auto vehiclesCount = GetVisCount(mgr);
+		auto vehicles = Dev::GetOffsetNod(mgr, VehiclesOffset);
+		for (uint i = 0; i < vehiclesCount; i++) {
+			auto vis = Dev::GetOffsetNod(vehicles, i * 0x8);
+			if (Dev::GetOffsetUint32(vis, 0x0) == VisId) {
+				return CSceneVehicleVisInner(vis);
 			}
 		}
 		return null;
@@ -87,12 +91,11 @@ namespace VehicleState
 	{
 		auto count = Dev::GetOffsetUint32(mgr, VehiclesOffset + 0x8);
 		// Assume we cannot have more than 1000 vehicles
-		if (count > 1000) return 0;
-		return count;
+		return (count <= 1000) ? count : 0;
 	}
 
-	// Get the raw vehicle vis at a particular index
-	CMwNod@ _GetVisNodAt(CSceneMgrVehicleVisImpl@ mgr, uint index)
+	// Get the raw vehicle vis at a particular index. (Note: not a real CMwNod.)
+	CMwNod@ GetVisNodAt(CSceneMgrVehicleVisImpl@ mgr, uint index)
 	{
 		if (index >= GetVisCount(mgr)) {
 			return null;
@@ -103,17 +106,18 @@ namespace VehicleState
 
 	bool CheckValidVehicles(CSceneMgrVehicleVisImpl@ mgr)
 	{
-		if (mgr is null) return false;
-
-		auto ptr = Dev::GetOffsetUint64(mgr, VehiclesOffset);
-		auto count = Dev::GetOffsetUint32(mgr, VehiclesOffset + 0x8);
+		if (mgr is null) {
+			return false;
+		}
 
 		// Ensure this is a valid pointer
+		auto ptr = Dev::GetOffsetUint64(mgr, VehiclesOffset);
 		if ((ptr & 0xF) != 0) {
 			return false;
 		}
 
 		// Assume we can't have more than 1000 vehicles
+		auto count = Dev::GetOffsetUint32(mgr, VehiclesOffset + 0x8);
 		if (count > 1000) {
 			return false;
 		}
@@ -125,12 +129,12 @@ namespace VehicleState
 	array<CSceneVehicleVisInner@> GetAllVis(CGameScene@ sceneVis)
 	{
 		array<CSceneVehicleVisInner@> ret;
-		auto mgr = SceneVis::GetManager(sceneVis);
+		auto mgr = SceneVis::GetVehicleVisManager(sceneVis);
 
 		if (mgr !is null && CheckValidVehicles(mgr)) {
 			auto vehiclesCount = GetVisCount(mgr);
 			for (uint i = 0; i < vehiclesCount; i++) {
-				ret.InsertLast(CSceneVehicleVisInner(VehicleState::_GetVisNodAt(mgr, i)));
+				ret.InsertLast(CSceneVehicleVisInner(VehicleState::GetVisNodAt(mgr, i)));
 			}
 		}
 
@@ -153,7 +157,7 @@ namespace VehicleState
 	// Get entity ID of the given vehicle vis.
 	uint GetEntityId(CSceneVehicleVisInner@ vis)
 	{
-		return vis.EntityId;
+		return vis.GetEntityId();
 	}
 }
 #endif

--- a/Internal/Vehicle/VehicleMP4.as
+++ b/Internal/Vehicle/VehicleMP4.as
@@ -39,21 +39,21 @@ namespace VehicleState
 	uint VehiclesOffset = 0x38;
 
 	// Get vehicle vis from a given player.
-	CSceneVehicleVisInner@ GetVis(CGameScene@ sceneVis, CGamePlayer@ player)
+	CSceneVehicleVisState@ GetVis(CGameScene@ sceneVis, CGamePlayer@ player)
 	{
 		if (player is null) {
 			return null;
 		}
-		return CSceneVehicleVisInner(player);
+		return CSceneVehicleVisInner(player).AsyncState;
 	}
 
 	// Get the only existing vehicle vis state, if there is only one. Otherwise, this returns null.
-	CSceneVehicleVisInner@ GetSingularVis(CGameScene@ sceneVis)
+	CSceneVehicleVisState@ GetSingularVis(CGameScene@ sceneVis)
 	{
 		auto mgr = SceneVis::GetVehicleVisManager(sceneVis);
 
 		if (CheckValidVehicles(mgr) && GetVisCount(mgr) == 1) {
-			return CSceneVehicleVisInner(mgr, 0);
+			return CSceneVehicleVisInner(mgr, 0).AsyncState;
 		}
 
 		return null;
@@ -126,15 +126,15 @@ namespace VehicleState
 	}
 
 	// Get all vehicle vis states. Mostly used for debugging.
-	array<CSceneVehicleVisInner@> GetAllVis(CGameScene@ sceneVis)
+	array<CSceneVehicleVisState@> GetAllVis(CGameScene@ sceneVis)
 	{
-		array<CSceneVehicleVisInner@> ret;
+		array<CSceneVehicleVisState@> ret;
 		auto mgr = SceneVis::GetVehicleVisManager(sceneVis);
 
 		if (mgr !is null && CheckValidVehicles(mgr)) {
 			auto vehiclesCount = GetVisCount(mgr);
 			for (uint i = 0; i < vehiclesCount; i++) {
-				ret.InsertLast(CSceneVehicleVisInner(VehicleState::GetVisNodAt(mgr, i)));
+				ret.InsertLast(CSceneVehicleVisInner(VehicleState::GetVisNodAt(mgr, i)).AsyncState);
 			}
 		}
 
@@ -158,6 +158,12 @@ namespace VehicleState
 	uint GetEntityId(CSceneVehicleVisInner@ vis)
 	{
 		return vis.GetEntityId();
+	}
+
+	// Get entity ID of the given vehicle vis.
+	uint GetEntityId(CSceneVehicleVisState@ vis)
+	{
+		return Dev::GetOffsetUint32(vis.m_vis, 0);
 	}
 }
 #endif

--- a/Internal/Vehicle/VehicleNext.as
+++ b/Internal/Vehicle/VehicleNext.as
@@ -42,15 +42,14 @@ namespace VehicleState
 
 	bool CheckValidVehicles(CMwNod@ vehicleVisMgr)
 	{
-		auto ptr = Dev::GetOffsetUint64(vehicleVisMgr, VehiclesOffset);
-		auto count = Dev::GetOffsetUint32(vehicleVisMgr, VehiclesOffset + 0x8);
-
 		// Ensure this is a valid pointer
+		auto ptr = Dev::GetOffsetUint64(vehicleVisMgr, VehiclesOffset);
 		if ((ptr & 0xF) != 0) {
 			return false;
 		}
 
 		// Assume we can't have more than 1000 vehicles
+		auto count = Dev::GetOffsetUint32(vehicleVisMgr, VehiclesOffset + 0x8);
 		if (count > 1000) {
 			return false;
 		}

--- a/Settings.as
+++ b/Settings.as
@@ -1,7 +1,12 @@
 [Setting category="Debug" name="Display debugger window" description="Displays information about vehicle states."]
 bool Setting_DisplayDebugger = false;
 
-#if TMNEXT
+#if TMNEXT || MP4
+[Setting category="Debug" name="Display debug vehicle axes" description="Draws Up, Left, and Direction vectors over the car."]
+bool Setting_DisplayDebugAxes = false;
+#endif
+
+#if TMNEXT || MP4
 [Setting category="Debug" name="Display extended information"]
 bool Setting_DisplayExtendedInformation = false;
 #endif

--- a/Settings.as
+++ b/Settings.as
@@ -2,11 +2,6 @@
 bool Setting_DisplayDebugger = false;
 
 #if TMNEXT || MP4
-[Setting category="Debug" name="Display debug vehicle axes" description="Draws Up, Left, and Direction vectors over the car."]
-bool Setting_DisplayDebugAxes = false;
-#endif
-
-#if TMNEXT || MP4
 [Setting category="Debug" name="Display extended information"]
 bool Setting_DisplayExtendedInformation = false;
 #endif

--- a/StateWrappers.as
+++ b/StateWrappers.as
@@ -1,5 +1,8 @@
 #if MP4
 
+// Note: these and the other offsets (except for .EntityId) are for a CSceneVehicleVis,
+// not CSceneVehicleVisState (which is an internal part of CSceneVehicleVis).
+
 const uint WheelsStartOffset = 0x53C;
 const uint WheelStructLength = 0x24;
 
@@ -23,6 +26,7 @@ shared class CSceneVehicleVisState
 		@this.m_vis = m_vis;
 	}
 
+	// This provides compatibility with the TMNEXT API when using functions like `GetAllVis`
 	CSceneVehicleVisState@ get_AsyncState()
 	{
 		return this;
@@ -92,8 +96,8 @@ shared class CSceneVehicleVisState
 	uint get_ActiveEffects() { if (m_vis is null) { return 0; } return Dev::GetOffsetUint32(m_vis, 0x630); }
 
 	bool get_TurboActive()  { if (m_vis is null) { return false; } return Dev::GetOffsetFloat(m_vis, 0x824) == 1.0; }
-	float get_TurboPct()  { if (m_vis is null) { return 0; } return Dev::GetOffsetFloat(m_vis, 0x830); }
-	float get_GearPct()  { if (m_vis is null) { return 0; } return Dev::GetOffsetFloat(m_vis, 0x83C); }
+	float get_TurboPercent()  { if (m_vis is null) { return 0; } return Dev::GetOffsetFloat(m_vis, 0x830); }
+	float get_GearPercent()  { if (m_vis is null) { return 0; } return Dev::GetOffsetFloat(m_vis, 0x83C); }
 }
 
 #elif TURBO

--- a/StateWrappers.as
+++ b/StateWrappers.as
@@ -1,52 +1,99 @@
 #if MP4
 
+const uint WheelsStartOffset = 0x53C;
+const uint WheelStructLength = 0x24;
+
+namespace VehicleState
+{
+	shared enum EffectFlags {
+		FreeWheeling = 1,
+		ForcedAcceleration = 2,
+		NoBrakes = 4,
+		NoSteering = 8,
+		NoGrip = 16
+	}
+}
+
 shared class CSceneVehicleVisState
 {
-	CTrackManiaPlayer@ m_player;
-	CTrackManiaScriptPlayer@ m_scriptapi;
+	CMwNod@ m_vis;
 
-	CSceneVehicleVisState(CTrackManiaPlayer@ player)
+	CSceneVehicleVisState(CMwNod@ m_vis)
 	{
-		@m_player = player;
-		@m_scriptapi = m_player.ScriptAPI;
+		@this.m_vis = m_vis;
 	}
 
-	float get_InputSteer() { if (m_scriptapi is null) { return 0; } return m_scriptapi.InputSteer; }
-	float get_InputGasPedal() { if (m_scriptapi is null) { return 0; } return m_scriptapi.InputGasPedal; }
-	float get_InputBrakePedal() { if (m_scriptapi is null) { return 0; } return m_scriptapi.InputIsBraking ? 1 : 0; }
-	bool get_InputIsBraking() { if (m_scriptapi is null) { return false; } return m_scriptapi.InputIsBraking; }
+	CSceneVehicleVisState@ get_AsyncState()
+	{
+		return this;
+	}
 
-	uint get_CurGear() { if (m_scriptapi is null) { return 0; } return m_scriptapi.EngineCurGear; }
+	uint get_EntityId() { if (m_vis is null) { return 0; } return Dev::GetOffsetUint32(m_vis, 0x0); }
 
-	float get_RPM() { if (m_scriptapi is null) { return 0; } return m_scriptapi.EngineRpm; }
+	float get_InputSteer() { if (m_vis is null) { return 0; } return Dev::GetOffsetFloat(m_vis, 0x4c0); }
+	float get_InputGasPedal() { if (m_vis is null) { return 0; } return Dev::GetOffsetFloat(m_vis, 0x4c4); }
+	float get_InputBrakePedal() { if (m_vis is null) { return 0; } return InputIsBraking ? 1 : 0; }
+	bool get_InputIsBraking() { if (m_vis is null) { return false; } return Dev::GetOffsetUint32(m_vis, 0x4cc) == 1; }
 
-	float get_FrontSpeed() { if (m_scriptapi is null) { return 0; } return m_scriptapi.Speed; }
-	float get_SideSpeed() { return 0; }
+	uint get_CurGear() { if (m_vis is null) { return 0; } return Dev::GetOffsetUint32(m_vis, 0x5f4); }
 
-	vec3 get_Position() { if (m_scriptapi is null) { return vec3(); } return m_scriptapi.Position; }
-	vec3 get_WorldVel() { return vec3(); }
+	float get_RPM() { if (m_vis is null) { return 0; } return Dev::GetOffsetFloat(m_vis, 0x5e8); }
 
+	float get_FrontSpeed() { if (m_vis is null) { return 0; } return Dev::GetOffsetFloat(m_vis, 0x528); }
+	float get_SideSpeed() { if (m_vis is null) { return 0; } return Dev::GetOffsetFloat(m_vis, 0x52C); }
+
+	iso4 get_Location() { if (m_vis is null) { return iso4(); } return Dev::GetOffsetIso4(m_vis, 0x4E0); }
+	vec3 get_Left() { if (m_vis is null) { return vec3(); } return vec3(Dev::GetOffsetFloat(m_vis, 0x4E0), Dev::GetOffsetFloat(m_vis, 0x4EC), Dev::GetOffsetFloat(m_vis, 0x4F8)); }
+	vec3 get_Up() { if (m_vis is null) { return vec3(); } return vec3(Dev::GetOffsetFloat(m_vis, 0x4E4), Dev::GetOffsetFloat(m_vis, 0x4F0), Dev::GetOffsetFloat(m_vis, 0x4FC)); }
+	vec3 get_Dir() { if (m_vis is null) { return vec3(); } return vec3(Dev::GetOffsetFloat(m_vis, 0x4E8), Dev::GetOffsetFloat(m_vis, 0x4F4), Dev::GetOffsetFloat(m_vis, 0x500)); }
+	vec3 get_Position() { if (m_vis is null) { return vec3(); } return Dev::GetOffsetVec3(m_vis, 0x504); }
+	vec3 get_WorldVel() { if (m_vis is null) { return vec3(); } return Dev::GetOffsetVec3(m_vis, 0x510); }
+
+	bool get_IsGroundContact() { if (m_vis is null) { return false; } return Dev::GetOffsetUint32(m_vis, 0x538) == 0x1; }
 	float get_GroundDist() { return 0; }
 
-	float get_FLWheelRot() { return 0; }
-	float get_FLWheelRotSpeed() { return 0; }
-	float get_FLSteerAngle() { return 0; }
-	float get_FLSlipCoef() { return 0; }
+	float get_FLDamperLen() { if (m_vis is null) { return 0; } return Dev::GetOffsetFloat(m_vis, WheelsStartOffset + (0 * WheelStructLength) + 0x00); }
+	float get_FLWheelRot() { if (m_vis is null) { return 0; } return Dev::GetOffsetFloat(m_vis, WheelsStartOffset + (0 * WheelStructLength) + 0x04); }
+	float get_FLWheelRotSpeed() { if (m_vis is null) { return 0; } return Dev::GetOffsetFloat(m_vis, WheelsStartOffset + (0 * WheelStructLength) + 0x08); }
+	float get_FLSteerAngle() { if (m_vis is null) { return 0; } return Dev::GetOffsetFloat(m_vis, WheelsStartOffset + (0 * WheelStructLength) + 0x0C); }
+	CAudioSourceSurface::ESurfId get_FLGroundContactMaterial() { if (m_vis is null) { return CAudioSourceSurface::ESurfId(0); } return CAudioSourceSurface::ESurfId(Dev::GetOffsetUint32(m_vis, WheelsStartOffset + (0 * WheelStructLength) + 0x10)); }
+	bool get_FLGroundContact() { if (m_vis is null) { return false; } return Dev::GetOffsetUint32(m_vis, WheelsStartOffset + (0 * WheelStructLength) + 0x14) == 0x1; }
+	float get_FLSlipCoef() { if (m_vis is null) { return 0; } return Dev::GetOffsetFloat(m_vis, WheelsStartOffset + (0 * WheelStructLength) + 0x18); }
+	bool get_FLIsWet() { if (m_vis is null) { return false; } return Dev::GetOffsetUint32(m_vis, WheelsStartOffset + (0 * WheelStructLength) + 0x20) == 0x1; }
 
-	float get_FRWheelRot() { return 0; }
-	float get_FRWheelRotSpeed() { return 0; }
-	float get_FRSteerAngle() { return 0; }
-	float get_FRSlipCoef() { return 0; }
+	float get_FRDamperLen() { if (m_vis is null) { return 0; } return Dev::GetOffsetFloat(m_vis, WheelsStartOffset + (1 * WheelStructLength) + 0x00); }
+	float get_FRWheelRot() { if (m_vis is null) { return 0; } return Dev::GetOffsetFloat(m_vis, WheelsStartOffset + (1 * WheelStructLength) + 0x04); }
+	float get_FRWheelRotSpeed() { if (m_vis is null) { return 0; } return Dev::GetOffsetFloat(m_vis, WheelsStartOffset + (1 * WheelStructLength) + 0x08); }
+	float get_FRSteerAngle() { if (m_vis is null) { return 0; } return Dev::GetOffsetFloat(m_vis, WheelsStartOffset + (1 * WheelStructLength) + 0x0C); }
+	CAudioSourceSurface::ESurfId get_FRGroundContactMaterial() { if (m_vis is null) { return CAudioSourceSurface::ESurfId(0); } return CAudioSourceSurface::ESurfId(Dev::GetOffsetUint32(m_vis, WheelsStartOffset + (1 * WheelStructLength) + 0x10)); }
+	bool get_FRGroundContact() { if (m_vis is null) { return false; } return Dev::GetOffsetUint32(m_vis, WheelsStartOffset + (1 * WheelStructLength) + 0x14) == 0x1; }
+	float get_FRSlipCoef() { if (m_vis is null) { return 0; } return Dev::GetOffsetFloat(m_vis, WheelsStartOffset + (1 * WheelStructLength) + 0x18); }
+	bool get_FRIsWet() { if (m_vis is null) { return false; } return Dev::GetOffsetUint32(m_vis, WheelsStartOffset + (1 * WheelStructLength) + 0x20) == 0x1; }
 
-	float get_RLWheelRot() { return 0; }
-	float get_RLWheelRotSpeed() { return 0; }
-	float get_RLSteerAngle() { return 0; }
-	float get_RLSlipCoef() { return 0; }
+	float get_RLDamperLen() { if (m_vis is null) { return 0; } return Dev::GetOffsetFloat(m_vis, WheelsStartOffset + (2 * WheelStructLength) + 0x00); }
+	float get_RLWheelRot() { if (m_vis is null) { return 0; } return Dev::GetOffsetFloat(m_vis, WheelsStartOffset + (2 * WheelStructLength) + 0x04); }
+	float get_RLWheelRotSpeed() { if (m_vis is null) { return 0; } return Dev::GetOffsetFloat(m_vis, WheelsStartOffset + (2 * WheelStructLength) + 0x08); }
+	float get_RLSteerAngle() { if (m_vis is null) { return 0; } return Dev::GetOffsetFloat(m_vis, WheelsStartOffset + (2 * WheelStructLength) + 0x0C); }
+	CAudioSourceSurface::ESurfId get_RLGroundContactMaterial() { if (m_vis is null) { return CAudioSourceSurface::ESurfId(0); } return CAudioSourceSurface::ESurfId(Dev::GetOffsetUint32(m_vis, WheelsStartOffset + (2 * WheelStructLength) + 0x10)); }
+	bool get_RLGroundContact() { if (m_vis is null) { return false; } return Dev::GetOffsetUint32(m_vis, WheelsStartOffset + (2 * WheelStructLength) + 0x14) == 0x1; }
+	float get_RLSlipCoef() { if (m_vis is null) { return 0; } return Dev::GetOffsetFloat(m_vis, WheelsStartOffset + (2 * WheelStructLength) + 0x18); }
+	bool get_RLIsWet() { if (m_vis is null) { return false; } return Dev::GetOffsetUint32(m_vis, WheelsStartOffset + (2 * WheelStructLength) + 0x20) == 0x1; }
 
-	float get_RRWheelRot() { return 0; }
-	float get_RRWheelRotSpeed() { return 0; }
-	float get_RRSteerAngle() { return 0; }
-	float get_RRSlipCoef() { return 0; }
+	float get_RRDamperLen() { if (m_vis is null) { return 0; } return Dev::GetOffsetFloat(m_vis, WheelsStartOffset + (3 * WheelStructLength) + 0x00); }
+	float get_RRWheelRot() { if (m_vis is null) { return 0; } return Dev::GetOffsetFloat(m_vis, WheelsStartOffset + (3 * WheelStructLength) + 0x04); }
+	float get_RRWheelRotSpeed() { if (m_vis is null) { return 0; } return Dev::GetOffsetFloat(m_vis, WheelsStartOffset + (3 * WheelStructLength) + 0x08); }
+	float get_RRSteerAngle() { if (m_vis is null) { return 0; } return Dev::GetOffsetFloat(m_vis, WheelsStartOffset + (3 * WheelStructLength) + 0x0C); }
+	CAudioSourceSurface::ESurfId get_RRGroundContactMaterial() { if (m_vis is null) { return CAudioSourceSurface::ESurfId(0); } return CAudioSourceSurface::ESurfId(Dev::GetOffsetUint32(m_vis, WheelsStartOffset + (3 * WheelStructLength) + 0x10)); }
+	bool get_RRGroundContact() { if (m_vis is null) { return false; } return Dev::GetOffsetUint32(m_vis, WheelsStartOffset + (3 * WheelStructLength) + 0x14) == 0x1; }
+	float get_RRSlipCoef() { if (m_vis is null) { return 0; } return Dev::GetOffsetFloat(m_vis, WheelsStartOffset + (3 * WheelStructLength) + 0x18); }
+	bool get_RRIsWet() { if (m_vis is null) { return false; } return Dev::GetOffsetUint32(m_vis, WheelsStartOffset + (3 * WheelStructLength) + 0x20) == 0x1; }
+
+	// Binary OR of `VehicleState::EffectFlags`
+	uint get_ActiveEffects() { if (m_vis is null) { return 0; } return Dev::GetOffsetUint32(m_vis, 0x630); }
+
+	bool get_TurboActive()  { if (m_vis is null) { return false; } return Dev::GetOffsetFloat(m_vis, 0x824) == 1.0; }
+	float get_TurboPct()  { if (m_vis is null) { return 0; } return Dev::GetOffsetFloat(m_vis, 0x830); }
+	float get_GearPct()  { if (m_vis is null) { return 0; } return Dev::GetOffsetFloat(m_vis, 0x83C); }
 }
 
 #elif TURBO


### PR DESCRIPTION
This implements a near-complete feature-set for MP4. 

I've done a code-style pass just before committing to try and catch any of my habits that don't mesh with your code style, please LMK if there are any issues there.

Still to-do:

- [x] Test outside TM2 (e.g., Lagoon)
- [x] Check Turbo stuff still works (nothing broken, no compile errors, etc)
- [x] Check TM2020 stuff still works

I don't think there's anything that is explicitly left to do before a code review.

Comments:

* Added some stuff to the debug screen that helped test new details
* Functions like `VehicleState::GetAllVis()` are a bit tricky for MP4 because the outer structure is returned in tm2020. However, the outer structure for MP4 is `CSceneVehicleVisStateInner` which is not a shared class. This presents API differences between TM2020 and MP4 (which will complicate a plugin being compatible with both of them). However, `.AsyncState` is the actually interesting thing, anyway (i.e., that's what ppl are after most of the time). So instead of making a new shared class, I added a `get_AsyncState() { return this; }` to `CSceneVehicleVisState`, which means that the same for loop over `GetAllVis()` can be used for both TM2020 and MP4.