### PR TITLE
Add support for currently spectated ghost

### DIFF
--- a/Export.as
+++ b/Export.as
@@ -32,6 +32,9 @@ namespace VehicleState
 	// Get vehicle vis from a given player.
 	import CSceneVehicleVis@ GetVis(ISceneVis@ sceneVis, CSmPlayer@ player) from "VehicleState";
 
+	// Get vehicle vis with a given entity ID.
+	import CSceneVehicleVis@ GetVis(ISceneVis@ sceneVis, uint vehicleEntityId) from "VehicleState";
+
 	// Get the only existing vehicle vis state, if there is only one. Otherwise, this returns null.
 	import CSceneVehicleVis@ GetSingularVis(ISceneVis@ sceneVis) from "VehicleState";
 

--- a/Internal/Impl.as
+++ b/Internal/Impl.as
@@ -78,7 +78,7 @@ namespace VehicleState
 				auto type = Reflection::GetType("CGameTerminal");
 				if (type !is null) {
 					auto offset = type.GetMember("MediaAmbianceClipPlayer").Offset + 0x68;
-					bool isWatchingGhost = Dev::GetOffsetUint8(gameTerminal, offset) > 0;
+					bool isWatchingGhost = Dev::GetOffsetUint8(gameTerminal, offset) == 1;
 					auto ghostVisEntId = Dev::GetOffsetUint32(gameTerminal, offset + 0x4);
 					if (isWatchingGhost && ghostVisEntId & 0x04000000 > 0) {
 						@vis = GetVis(sceneVis, ghostVisEntId);

--- a/Internal/Impl.as
+++ b/Internal/Impl.as
@@ -1,13 +1,22 @@
 namespace VehicleState
 {
 #if TMNEXT
-	CSmPlayer@ GetViewingPlayer()
+	CGameTerminal@ GetGameTerminal()
 	{
 		auto playground = GetApp().CurrentPlayground;
 		if (playground is null || playground.GameTerminals.Length != 1) {
 			return null;
 		}
-		return cast<CSmPlayer>(playground.GameTerminals[0].GUIPlayer);
+		return playground.GameTerminals[0];
+	}
+
+	CSmPlayer@ GetViewingPlayer()
+	{
+		auto gameTerminal = GetGameTerminal();
+		if (gameTerminal is null) {
+			return null;
+		}
+		return cast<CSmPlayer>(gameTerminal.GUIPlayer);
 	}
 #elif TURBO
 	CGameMobil@ GetViewingPlayer()
@@ -59,6 +68,23 @@ namespace VehicleState
 			@vis = VehicleState::GetVis(sceneVis, player);
 		} else {
 			@vis = VehicleState::GetSingularVis(sceneVis);
+		}
+#endif
+
+#if TMNEXT
+		if (vis is null) {
+			auto gameTerminal = GetGameTerminal();
+			if (gameTerminal !is null) {
+				auto type = Reflection::GetType("CGameTerminal");
+				if (type !is null) {
+					auto offset = type.GetMember("MediaAmbianceClipPlayer").Offset + 0x68;
+					bool isWatchingGhost = Dev::GetOffsetUint8(gameTerminal, offset) > 0;
+					auto ghostVisEntId = Dev::GetOffsetUint32(gameTerminal, offset + 0x4);
+					if (isWatchingGhost && ghostVisEntId & 0x04000000 > 0) {
+						@vis = GetVis(sceneVis, ghostVisEntId);
+					}
+				}
+			}
 		}
 #endif
 

--- a/Internal/SceneVis.as
+++ b/Internal/SceneVis.as
@@ -13,7 +13,7 @@ namespace SceneVis
 	CMwNod@ GetManager(ISceneVis@ sceneVis, uint index)
 	{
 		uint managerCount = Dev::GetOffsetUint32(sceneVis, 0x8);
-		if (index > managerCount) {
+		if (index >= managerCount) {
 			error("Index out of range: there are only " + managerCount + " managers");
 			return null;
 		}

--- a/Internal/Vehicle/VehicleNext.as
+++ b/Internal/Vehicle/VehicleNext.as
@@ -66,8 +66,12 @@ namespace VehicleState
 	// Get vehicle vis from a given player.
 	CSceneVehicleVis@ GetVis(ISceneVis@ sceneVis, CSmPlayer@ player)
 	{
-		uint vehicleEntityId = GetPlayerVehicleID(player);
+		return GetVis(sceneVis, GetPlayerVehicleID(player));
+	}
 
+	// Get vehicle vis with a given entity ID.
+	CSceneVehicleVis@ GetVis(ISceneVis@ sceneVis, uint vehicleEntityId)
+	{
 		auto vehicleVisMgr = SceneVis::GetManager(sceneVis, VehiclesManagerIndex); // NSceneVehicleVis_SMgr
 		if (vehicleVisMgr is null) {
 			return null;


### PR DESCRIPTION
Alternate solution for #4. 
I noticed that there was an entity ID set under game terminal which is the current ghost you're spectating. it's 0 otherwise. Additionally there's a flag right before it that's true/false depending on whether you're watching a ghost or not.