### PR TITLE
+WheelFalling, LastTurboLevel, ReactorFinalTimer

### DIFF
--- a/Export.as
+++ b/Export.as
@@ -34,6 +34,7 @@ namespace VehicleState
 	//  1 = Front Right
 	//  2 = Rear Left
 	//  3 = Rear Right
+	// The value returned seems to always be even (0, 2, 4, 6), but this could break.
 	import FallingState GetWheelFalling(CSceneVehicleVisState@ vis, int w) from "VehicleState";
 
 	// Get the last turbo level that the vehicle touched. This will return the last level

--- a/Export.as
+++ b/Export.as
@@ -36,7 +36,8 @@ namespace VehicleState
 	//  3 = Rear Right
 	import FallingState GetWheelFalling(CSceneVehicleVisState@ vis, int w) from "VehicleState";
 
-	// Get the last turbo level that the vehicle touched.
+	// Get the last turbo level that the vehicle touched. This will return the last level
+	// even if the vehicle is not currently in contact with a turbo gate/surface.
 	import TurboLevel GetLastTurboLevel(CSceneVehicleVisState@ vis) from "VehicleState";
 
 	// Get a timer which counts from 0.0 to 1.0 in the final second of reactor boost.

--- a/Export.as
+++ b/Export.as
@@ -34,7 +34,9 @@ namespace VehicleState
 	//  1 = Front Right
 	//  2 = Rear Left
 	//  3 = Rear Right
-	// The value returned seems to always be even (0, 2, 4, 6), but this could break.
+	// The value returned seems to always be even (0, 2, 4, 6), but this may be completely
+	// incorrect and give unexpected results. It is only present here because it technically
+	// exists in-game and may be useful to someone.
 	import FallingState GetWheelFalling(CSceneVehicleVisState@ vis, int w) from "VehicleState";
 
 	// Get the last turbo level that the vehicle touched. This will return the last level

--- a/Export.as
+++ b/Export.as
@@ -29,6 +29,20 @@ namespace VehicleState
 	//  3 = Rear Right
 	import float GetWheelDirt(CSceneVehicleVisState@ vis, int w) from "VehicleState";
 
+	// Get wheel falling state, and if in water. For w, use one of the following:
+	//  0 = Front Left
+	//  1 = Front Right
+	//  2 = Rear Left
+	//  3 = Rear Right
+	import FallingState GetWheelFalling(CSceneVehicleVisState@ vis, int w) from "VehicleState";
+
+	// Get the last turbo level that the vehicle touched.
+	import TurboLevel GetLastTurboLevel(CSceneVehicleVisState@ vis) from "VehicleState";
+
+	// Get a timer which counts from 0.0 to 1.0 in the final second of reactor boost.
+	// Doesn't seem to work when watching a replay.
+	import float GetReactorFinalTimer(CSceneVehicleVisState@ vis) from "VehicleState";
+
 	// Get vehicle vis from a given player.
 	import CSceneVehicleVis@ GetVis(ISceneVis@ sceneVis, CSmPlayer@ player) from "VehicleState";
 

--- a/Internal/Vehicle/VehicleNext.as
+++ b/Internal/Vehicle/VehicleNext.as
@@ -195,6 +195,7 @@ namespace VehicleState
 	//  1 = Front Right
 	//  2 = Rear Left
 	//  3 = Rear Right
+	// The value returned seems to always be even (0, 2, 4, 6), but this could break.
 	FallingState GetWheelFalling(CSceneVehicleVisState@ vis, int w)
 	{
 		if (g_offsetWheelFalling.Length == 0) {

--- a/Internal/Vehicle/VehicleNext.as
+++ b/Internal/Vehicle/VehicleNext.as
@@ -214,8 +214,9 @@ namespace VehicleState
 
 		int state = Dev::GetOffsetInt32(vis, g_offsetWheelFalling[w]);
 		array<int> states = {0, 2, 4, 6};
-		if (states.Find(state) == -1)
+		if (states.Find(state) == -1) {
 			return FallingState(0);
+		}
 		return FallingState(state);
 	}
 
@@ -233,8 +234,9 @@ namespace VehicleState
 		}
 
 		uint level = Dev::GetOffsetUint32(vis, g_offsetLastTurboLevel);
-		if (level < 1 || level > 5)
+		if (level < 1 || level > 5) {
 			return TurboLevel(0);
+		}
 		return TurboLevel(level);
 	}
 

--- a/Internal/Vehicle/VehicleNext.as
+++ b/Internal/Vehicle/VehicleNext.as
@@ -216,7 +216,8 @@ namespace VehicleState
 		return FallingState(state);
 	}
 
-	// Get the last turbo level that the vehicle touched.
+	// Get the last turbo level that the vehicle touched. This will return the last level
+	// even if the vehicle is not currently in contact with a turbo gate/surface.
 	TurboLevel GetLastTurboLevel(CSceneVehicleVisState@ vis)
 	{
 		if (g_offsetLastTurboLevel == 0) {

--- a/Internal/Vehicle/VehicleNext.as
+++ b/Internal/Vehicle/VehicleNext.as
@@ -195,7 +195,9 @@ namespace VehicleState
 	//  1 = Front Right
 	//  2 = Rear Left
 	//  3 = Rear Right
-	// The value returned seems to always be even (0, 2, 4, 6), but this could break.
+	// The value returned seems to always be even (0, 2, 4, 6), but this may be completely
+	// incorrect and give unexpected results. It is only present here because it technically
+	// exists in-game and may be useful to someone.
 	FallingState GetWheelFalling(CSceneVehicleVisState@ vis, int w)
 	{
 		if (g_offsetWheelFalling.Length == 0) {

--- a/StateWrappers.as
+++ b/StateWrappers.as
@@ -1,4 +1,25 @@
-#if MP4
+#if TMNEXT
+
+namespace VehicleState
+{
+	shared enum FallingState {
+		FallingAir = 0,
+		FallingWater = 2,
+		RestingGround = 4,
+		RestingWater = 6
+	}
+
+	shared enum TurboLevel {
+		None,
+		Normal,
+		Super,
+		RouletteNormal,
+		RouletteSuper,
+		RouletteUltra
+	}
+}
+
+#elif MP4
 
 // Note: these and the other offsets (except for .EntityId) are for a CSceneVehicleVis,
 // not CSceneVehicleVisState (which is an internal part of CSceneVehicleVis).


### PR DESCRIPTION
I found some more values inside of `CSceneVehicleVisState` that are not exposed by default, at least for TM2020.