### PR TITLE
fix cruise offset (12 decimal, not 0x12 hex)

### DIFF
--- a/Main.as
+++ b/Main.as
@@ -31,7 +31,7 @@ void Main()
 		VehicleState::Internal::OffsetWheelFalling.InsertLast(FindRelativeOffset(typeVehicleVisState, "RRBreakNormedCoef", +0x4));
 		VehicleState::Internal::OffsetLastTurboLevel = FindRelativeOffset(typeVehicleVisState, "ReactorBoostLvl", -0x4);
 		VehicleState::Internal::OffsetReactorFinalTimer = FindRelativeOffset(typeVehicleVisState, "ReactorBoostType", +0x4);
-		VehicleState::Internal::OffsetCruiseDisplaySpeed = FindRelativeOffset(typeVehicleVisState, "FrontSpeed", 0x12);
+		VehicleState::Internal::OffsetCruiseDisplaySpeed = FindRelativeOffset(typeVehicleVisState, "FrontSpeed", +0xC);
 		VehicleState::Internal::OffsetVehicleType = FindRelativeOffset(typeVehicleVisState, "InputSteer", -0x8);
 	} else {
 		error("Unable to find reflection info for CSceneVehicleVisState!");


### PR DESCRIPTION
small thing that I guess was overlooked, I found the offset to be 12 but 49cc60e changed it to 0x12 which would be 18