### PR TITLE
add `GetVisFromId(ISceneVis@ sceneVis, uint vehicleEntityId)` export

### DIFF
--- a/Export.as
+++ b/Export.as
@@ -57,6 +57,9 @@ namespace VehicleState
 	// Get vehicle vis from a given player.
 	import CSceneVehicleVis@ GetVis(ISceneVis@ sceneVis, CSmPlayer@ player) from "VehicleState";
 
+	// Get the vehicle vis with the given entity ID.
+	import CSceneVehicleVis@ GetVisFromId(ISceneVis@ sceneVis, uint vehicleEntityId) from "VehicleState";
+
 	// Get the only existing vehicle vis state, if there is only one. Otherwise, this returns null.
 	import CSceneVehicleVis@ GetSingularVis(ISceneVis@ sceneVis) from "VehicleState";
 

--- a/Internal/Vehicle/VehicleNext.as
+++ b/Internal/Vehicle/VehicleNext.as
@@ -44,8 +44,13 @@ namespace VehicleState
 	// Get vehicle vis from a given player.
 	CSceneVehicleVis@ GetVis(ISceneVis@ sceneVis, CSmPlayer@ player)
 	{
-		uint vehicleEntityId = GetPlayerVehicleID(player);
+		return GetVisFromId(sceneVis, GetPlayerVehicleID(player));
+	}
 
+
+	// Get the vehicle vis with the given entity ID.
+	CSceneVehicleVis@ GetVisFromId(ISceneVis@ sceneVis, uint vehicleEntityId)
+	{
 		auto vehicleVisMgr = SceneVis::GetManager(sceneVis, VehiclesManagerIndex); // NSceneVehicleVis_SMgr
 		if (vehicleVisMgr is null) {
 			return null;


### PR DESCRIPTION
Plugins can already find specific vehicles via `GetAllVis` but this is more efficient given it doesn't need to allocate memory for an array.

It maintains the default behavior from `GetVis` where requesting an ent id of 0 will return the first player vis.